### PR TITLE
Fix type issues with Typescript 4

### DIFF
--- a/src/express.ts
+++ b/src/express.ts
@@ -1,168 +1,195 @@
 // @ts-ignore
-import Debug from 'debug';
-import { Application } from '@feathersjs/feathers';
-import { AuthenticationResult } from '@feathersjs/authentication';
+import Debug from 'debug'
+import { Application } from '@feathersjs/feathers'
+import { AuthenticationResult } from '@feathersjs/authentication'
 import {
   Application as ExpressApplication,
   original as express
-} from '@feathersjs/express';
-import { SamlSetupSettings } from './utils';
-import { SamlStrategy } from './strategy';
-import { BadRequest } from '@feathersjs/errors';
- 
-const debug = Debug('feathers-saml/express');
+} from '@feathersjs/express'
+import { SamlSetupSettings } from './utils'
+import { SamlStrategy } from './strategy'
+import { BadRequest } from '@feathersjs/errors'
+
+const debug = Debug('feathers-saml/express')
 
 export default (options: SamlSetupSettings) => {
   return (feathersApp: Application) => {
-    const { authService } = options;
-    const app = feathersApp as ExpressApplication;
-    const config = app.get(authService + 'Saml');
+    const { authService } = options
+    const app = feathersApp as ExpressApplication
+    const config = app.get(authService + 'Saml')
 
     if (!config) {
-      debug('No SAML configuration found, skipping Express SAML setup');
-      return;
+      debug('No SAML configuration found, skipping Express SAML setup')
+      return
     }
 
     if (!config.sp) {
-      debug('No SAML SP found, skipping Express SAML setup');
-      return;
+      debug('No SAML SP found, skipping Express SAML setup')
+      return
     }
 
     if (!config.idp) {
-      debug('No SAML IdP found, skipping Express SAML setup');
-      return;
+      debug('No SAML IdP found, skipping Express SAML setup')
+      return
     }
 
-    const { sp, idp, path } = config;
+    const { sp, idp, path } = config
 
-    const authApp = express();
-    
-    authApp.get('/', async (req, res) => {
-      sp.create_login_request_url(idp, config.loginRequestOptions ? config.loginRequestOptions : {}, async (err: Error, login_url: string, request_id: string) => {
-        if (err != null) {
-          return res.send(500);
-        } 
+    const authApp = express()
 
-        res.redirect(login_url);
-      });
-    });
+    authApp.get('/', async (req: any, res: any) => {
+      sp.create_login_request_url(
+        idp,
+        config.loginRequestOptions ? config.loginRequestOptions : {},
+        async (err: Error, login_url: string, request_id: string) => {
+          if (err != null) {
+            return res.send(500)
+          }
 
-    authApp.get('/metadata.xml', async (req, res) => {
-      res.type('application/xml');
-      res.send(sp.create_metadata());
-    });
+          res.redirect(login_url)
+        }
+      )
+    })
 
-    authApp.post('/assert', async (req, res, next) => {
-      const service = app.defaultAuthentication(authService);
-      const [ strategy ] = service.getStrategies('saml') as SamlStrategy[];
+    authApp.get('/metadata.xml', async (req: any, res: any) => {
+      res.type('application/xml')
+      res.send(sp.create_metadata())
+    })
+
+    authApp.post('/assert', async (req: any, res: any, next: any) => {
+      const service = app.defaultAuthentication(authService)
+      const [strategy] = service.getStrategies('saml') as SamlStrategy[]
       const params: any = {
-        authStrategies: [ strategy.name ]
-      };
-      const sendResponse = async (data: AuthenticationResult|Error) => {
+        authStrategies: [strategy.name]
+      }
+      const sendResponse = async (data: AuthenticationResult | Error) => {
         try {
-          const redirect = await strategy.getRedirect(data, params);
+          const redirect = await strategy.getRedirect(data, params)
 
           if (redirect !== null) {
-            res.redirect(redirect);
+            res.redirect(redirect)
           } else if (data instanceof Error) {
-            throw data;
+            throw data
           } else {
-            res.json(data);
+            res.json(data)
           }
         } catch (error) {
-          debug('SAML error', error);
-          next(error);
+          debug('SAML error', error)
+          next(error)
         }
-      };
+      }
 
       try {
         const samlResponse: any = await new Promise((resolve, reject) => {
-          let loginResponseOptions: any = {};
+          let loginResponseOptions: any = {}
 
           if (config.loginResponseOptions) {
-            loginResponseOptions = config.loginResponseOptions;
+            loginResponseOptions = config.loginResponseOptions
           }
-  
-          loginResponseOptions.request_body = req.body;
-          
-          sp.post_assert(idp, loginResponseOptions, async (err: Error, saml_response: any) => {
-            if (err != null) {
-              reject(err);
-              return;
+
+          loginResponseOptions.request_body = req.body
+
+          sp.post_assert(
+            idp,
+            loginResponseOptions,
+            async (err: Error, saml_response: any) => {
+              if (err != null) {
+                reject(err)
+                return
+              }
+
+              resolve(saml_response)
             }
-        
-            resolve(saml_response);
-          });
-        });
+          )
+        })
 
         const authentication = {
           strategy: strategy.name,
           ...samlResponse
-        };
+        }
 
         params.payload = {
-          nameId: samlResponse && samlResponse.user && samlResponse.user.name_id ? samlResponse.user.name_id : null,
-          sessionIndex: samlResponse && samlResponse.user && samlResponse.user.session_index ? samlResponse.user.session_index : null,
+          nameId:
+            samlResponse && samlResponse.user && samlResponse.user.name_id
+              ? samlResponse.user.name_id
+              : null,
+          sessionIndex:
+            samlResponse && samlResponse.user && samlResponse.user.session_index
+              ? samlResponse.user.session_index
+              : null,
           samlToken: true
-        };
-        
-        debug(`Calling ${authService}.create authentication with SAML strategy`);
+        }
+
+        debug(`Calling ${authService}.create authentication with SAML strategy`)
 
         if (config.samlTokenExpiry) {
           params.jwtOptions = {
             expiresIn: config.samlTokenExpiry
-          };
+          }
         }
 
-        const authResult = await service.create(authentication, params);
+        const authResult = await service.create(authentication, params)
 
-        debug('Successful SAML authentication, sending response');
+        debug('Successful SAML authentication, sending response')
 
-        await sendResponse(authResult);
+        await sendResponse(authResult)
       } catch (error) {
-        debug('Received SAML authentication error', error.stack);
-        await sendResponse(error);
+        if (error instanceof Error) {
+          debug('Received SAML authentication error', error.stack)
+          await sendResponse(error)
+        }
       }
-    });
+    })
 
-    authApp.get('/logout', async (req, res, next) => {
-      const { nameId, sessionIndex } = req.query;
+    authApp.get('/logout', async (req: any, res: any, next: any) => {
+      const { nameId, sessionIndex } = req.query
 
       if (!nameId || !sessionIndex) {
-        return next(new BadRequest('`nameId` and `sessionIndex` must be set in query params'));
+        return next(
+          new BadRequest(
+            '`nameId` and `sessionIndex` must be set in query params'
+          )
+        )
       }
-      
-      let logoutRequestOptions: any = {};
+
+      let logoutRequestOptions: any = {}
 
       if (config.logoutRequestOptions) {
-        logoutRequestOptions = config.logoutRequestOptions;
+        logoutRequestOptions = config.logoutRequestOptions
       }
 
-      logoutRequestOptions.name_id = nameId;
-      logoutRequestOptions.session_ndex = sessionIndex;
+      logoutRequestOptions.name_id = nameId
+      logoutRequestOptions.session_ndex = sessionIndex
 
-      sp.create_logout_request_url(idp, logoutRequestOptions, async (err: Error, logout_url: string) => {
-        if (err != null) {
-          next(err);
-          return;
+      sp.create_logout_request_url(
+        idp,
+        logoutRequestOptions,
+        async (err: Error, logout_url: string) => {
+          if (err != null) {
+            next(err)
+            return
+          }
+
+          res.redirect(logout_url)
         }
+      )
+    })
 
-        res.redirect(logout_url);
-      });
-    });
+    authApp.get('/slo', async (req: any, res: any, next: any) => {
+      sp.create_logout_response_url(
+        idp,
+        config.logoutResponseOptions ? config.logoutResponseOptions : {},
+        async (err: Error, request_url: string) => {
+          if (err != null) {
+            next(err)
+            return
+          }
 
-    authApp.get('/slo', async (req, res, next) => {
-      sp.create_logout_response_url(idp, config.logoutResponseOptions ? config.logoutResponseOptions : {}, async (err: Error, request_url: string) => {
-        if (err != null) {
-          next(err);
-          return;
+          res.redirect(request_url)
         }
+      )
+    })
 
-        res.redirect(request_url);
-      });
-    });
-
-
-    app.use(path, authApp);
-  };
-};
+    app.use(path, authApp)
+  }
+}

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -1,139 +1,167 @@
 // @ts-ignore
-import querystring from 'querystring';
-import Debug from 'debug';
+import querystring from 'querystring'
+import Debug from 'debug'
 import {
-  AuthenticationRequest, AuthenticationBaseStrategy, AuthenticationResult
-} from '@feathersjs/authentication';
-import { Params } from '@feathersjs/feathers';
+  AuthenticationRequest,
+  AuthenticationBase,
+  AuthenticationBaseStrategy,
+  AuthenticationResult
+} from '@feathersjs/authentication'
+import { Application, Params } from '@feathersjs/feathers'
 
-const debug = Debug('feathers-saml/strategy');
+const debug = Debug('feathers-saml/strategy')
 
 export interface SamlUser {
-    name_id: String|number,
-    session_index: String|number,
-    attributes: {
-        [key: string]: any;
-    }   
+  name_id: String | number
+  session_index: String | number
+  attributes: {
+    [key: string]: any
+  }
 }
 
 export class SamlStrategy extends AuthenticationBaseStrategy {
-    get configuration () {
-        const authConfig = this.authentication.configuration;
-        const config = super.configuration || {};
-    
-        return {
-            service: authConfig.service,
-            entity: authConfig.entity,
-            entityId: authConfig.entityId,
-            ...config
-          };
+  name = 'SamlStrategy'
+
+  get configuration() {
+    const authConfig = this.authentication
+      ? {
+          service: this.authentication.configuration.service,
+          entity: this.authentication.configuration.entity,
+          entityId: this.authentication.configuration.entityId
+        }
+      : {}
+    const config = super.configuration || {}
+
+    return {
+      ...authConfig,
+      ...config
     }
-
-  get entityId (): string {
-    const { entityService } = this;
-
-    return this.configuration.entityId || (entityService && entityService.id);
   }
 
-  async getEntityQuery (samlUser: SamlUser, _params: Params) {
+  get entityId(): string {
+    const { entityService } = this
+
+    return this.configuration.entityId || (entityService && entityService.id)
+  }
+
+  async getEntityQuery(samlUser: SamlUser, _params: Params) {
     return {
       [`email`]: samlUser.attributes.email
-    };
+    }
   }
 
-  async getEntityData (samlUser: SamlUser, _existingEntity: any, _params: Params) {
+  async getEntityData(
+    samlUser: SamlUser,
+    _existingEntity: any,
+    _params: Params
+  ) {
     return {
-        [`email`]: samlUser.attributes.email,
-        [`nameId`]: samlUser.name_id,
-        [`sessionIndex`]: samlUser.session_index
-    };
+      [`email`]: samlUser.attributes.email,
+      [`nameId`]: samlUser.name_id,
+      [`sessionIndex`]: samlUser.session_index
+    }
   }
 
   /* istanbul ignore next */
-  async getSamlUser (data: AuthenticationRequest, _params: Params) {
-    return data.user;
+  async getSamlUser(data: AuthenticationRequest, _params: Params) {
+    return data.user
   }
 
-  async getCurrentEntity (params: Params) {
-    const { authentication } = params;
-    const { entity } = this.configuration;
+  async getCurrentEntity(params: Params) {
+    const { authentication } = params
+    const { entity } = this.configuration
 
     if (authentication && authentication.strategy) {
-      debug('getCurrentEntity with authentication', authentication);
+      debug('getCurrentEntity with authentication', authentication)
 
-      const { strategy } = authentication;
-      const authResult = await this.authentication.authenticate(authentication, params, strategy);
+      const { strategy } = authentication
+      const authResult = await authentication.authenticate(
+        authentication,
+        params,
+        strategy
+      )
 
-      return authResult[entity];
+      return authResult[entity]
     }
 
-    return null;
+    return null
   }
 
-  async getRedirect (data: AuthenticationResult|Error, params?: Params) {
-    const { redirect } = this.authentication.configuration.saml;
-
-    if (!redirect) {
-      return null;
+  async getRedirect(data: AuthenticationResult | Error, params?: Params) {
+    if (
+      !(this.authentication && this.authentication.configuration.saml.redirect)
+    ) {
+      return null
     }
 
-    const separator = redirect.endsWith('?') ? '' :
-      (redirect.indexOf('#') !== -1 ? '?' : '#');
-    const authResult: AuthenticationResult = data;
-    const query = authResult.accessToken ? {
-      access_token: authResult.accessToken
-    } : {
-      error: data.message || 'SAML Authentication not successful'
-    };
+    const { redirect } = this.authentication.configuration.saml
 
-    return redirect + separator + querystring.stringify(query);
+    const separator = redirect.endsWith('?')
+      ? ''
+      : redirect.indexOf('#') !== -1
+      ? '?'
+      : '#'
+    const authResult: AuthenticationResult = data
+    const query = authResult.accessToken
+      ? {
+          access_token: authResult.accessToken
+        }
+      : {
+          error: data.message || 'SAML Authentication not successful'
+        }
+
+    return redirect + separator + querystring.stringify(query)
   }
 
-  async findEntity (samlUser: SamlUser, params: Params) {
-    const query = await this.getEntityQuery(samlUser, params);
+  async findEntity(samlUser: SamlUser, params: Params) {
+    const query = await this.getEntityQuery(samlUser, params)
 
-    debug('findEntity with query', query);
+    debug('findEntity with query', query)
 
     const result = await this.entityService.find({
       ...params,
       query
-    });
-    const [ entity = null ] = result.data ? result.data : result;
+    })
+    const [entity = null] = result.data ? result.data : result
 
-    debug('findEntity returning', entity);
+    debug('findEntity returning', entity)
 
-    return entity;
+    return entity
   }
 
-  async createEntity (samlUser: SamlUser, params: Params) {
-    const data = await this.getEntityData(samlUser, null, params);
+  async createEntity(samlUser: SamlUser, params: Params) {
+    const data = await this.getEntityData(samlUser, null, params)
 
-    debug('createEntity with data', data);
+    debug('createEntity with data', data)
 
-    return this.entityService.create(data, params);
+    return this.entityService.create(data, params)
   }
 
-  async updateEntity (entity: any, samlUser: SamlUser, params: Params) {
-    const id = entity[this.entityId];
-    const data = await this.getEntityData(samlUser, entity, params);
+  async updateEntity(entity: any, samlUser: SamlUser, params: Params) {
+    const id = entity[this.entityId]
+    const data = await this.getEntityData(samlUser, entity, params)
 
-    debug(`updateEntity with id ${id} and data`, data);
+    debug(`updateEntity with id ${id} and data`, data)
 
-    return this.entityService.patch(id, data, params);
+    return this.entityService.patch(id, data, params)
   }
 
-  async authenticate (authentication: AuthenticationRequest, params: Params) {
-    const entity: string = this.configuration.entity;
-    const samlUser: SamlUser = await this.getSamlUser(authentication, params);
-    const existingEntity = await this.findEntity(samlUser, params) || await this.getCurrentEntity(params);
+  async authenticate(authentication: AuthenticationRequest, params: Params) {
+    const entity: string = this.configuration.entity
+    const samlUser: SamlUser = await this.getSamlUser(authentication, params)
+    const existingEntity =
+      (await this.findEntity(samlUser, params)) ||
+      (await this.getCurrentEntity(params))
 
-    debug(`authenticate with (existing) entity`, existingEntity);
+    debug(`authenticate with (existing) entity`, existingEntity)
 
-    const authEntity = !existingEntity ? await this.createEntity(samlUser, params) : await this.updateEntity(existingEntity, samlUser, params);
+    const authEntity = !existingEntity
+      ? await this.createEntity(samlUser, params)
+      : await this.updateEntity(existingEntity, samlUser, params)
 
     return {
       authentication: { strategy: this.name },
       [entity]: authEntity
-    };
+    }
   }
 }


### PR DESCRIPTION
The catch blocks have some "new" syntax we need to adhere to: https://github.com/microsoft/TypeScript/issues/36775

As of Feathers 4, the request and response body are actually of type any, but we have to specify that explicitly.

We can probably get rid of this `// @ts-ignore` now.

I also went ahead and fixed some other type issues with strategy.ts
`Type 'SamlStrategy' has no properties in common with type AuthenticationBase.`
https://stackoverflow.com/questions/46449237/type-x-has-no-properties-in-common-with-type-y